### PR TITLE
Remove exit animation and Animate project card on entry once

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -83,7 +83,7 @@ const Links = styled.div`
 
 const Card = ({ title, img, alt, github, hostLink, stacks, detail, delay }) => {
   return (
-    <ScrollAnimation animateIn="zoomIn" animateOut="zoomOut" delay={delay}>
+    <ScrollAnimation animateIn="zoomIn" delay={delay} animateOnce>
       <CardContainer>
         <ImgContainer>
           <img src={img} alt={alt} />


### PR DESCRIPTION
**What does this PR do**
Implement feedback from @richanynguon 👍
- Add animateOnce to Scroll animation
- Remove Exit animation